### PR TITLE
Fix upload error on macosx

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -29,7 +29,7 @@ if upload_protocol.startswith("svl"):
     if sys_pf.system() == "Windows":
         upload_program += ".exe"
 
-    elif sys_pf.system().lower() in ["Darwin"]:
+    elif sys_pf.system().lower() in ["darwin"]:
         upload_program = join(FRAMEWORK_DIR, "tools", "artemis", "macosx", "artemis_svl")
 
 upload_speed = env.subst("$UPLOAD_SPEED")


### PR DESCRIPTION
The platformio upload command fails on macOS. This is because the
path to artemis_svl determined by the python builder script (main.py)
is incorrect due to a bad conditional assignment. The condition for
setting the appropriate path on a macOS was guaranteed to be always
false because a lower case word is compared to a capitalize.