### PR TITLE
Include auto-detection of serial port for upload

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -36,7 +36,10 @@ upload_speed = env.subst("$UPLOAD_SPEED")
 if len(upload_speed) == 0:
     upload_speed = "921600"
 
-
+upload_port = env.subst("$UPLOAD_PORT")
+if len(upload_port) == 0:
+    env.AutodetectUploadPort()
+    
     # env.Replace(
     #     UPLOADER=upload_program,
     #     UPLOADERFLAGS=[


### PR DESCRIPTION
Previously, user is required to specify upload_port and
upload_speed environment variables in platform.ini file before
new firmware can be uploaded to target. With this fix, builtin
platformio environment utility is used to automatically identify
the port name of connected target device. User can still provide
both the port and speed if desired, which is the default. But if
they don't, upload should still work using default 921600 default
SVL speed.