### PR TITLE
Fix typo in include dirs

### DIFF
--- a/builder/frameworks/arduino/core_v2.py
+++ b/builder/frameworks/arduino/core_v2.py
@@ -134,7 +134,7 @@ env.Append(
         BOARD_VARIANTS_DIR,
         BRIDGE_DIR,
         join(BRIDGE_DIR, "core-api"),
-        join(BRIDGE_DIR, "core-api", "api", "depricated"),
+        join(BRIDGE_DIR, "core-api", "api", "deprecated"),
     ],
 
     LINKFLAGS=[


### PR DESCRIPTION
A minor bug that prevented deprecated header files from being included. This broke some libraries.